### PR TITLE
apppyのclientchat postmessageとclientchat updateの引数attachmentsが非推奨となっていた為blocksに置き換えた

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,7 +63,10 @@ def test_form(ack: Ack, body: dict, client: WebClient, say):
             print(f"エラーが発生しました: {e}")
 
     else:
-        say("ユーザー権限がありません")
+        client.views_open(
+            trigger_id=body["trigger_id"],
+            view=error_dialog(message="ユーザー権限がありません。"),
+        )
 
 # 有給申請
 @bolt_app.command("/form")
@@ -91,7 +94,8 @@ def paid_holiday_request_callback(ack: Ack, body, view: dict, client: WebClient)
     client.chat_postMessage(
             channel="有給登録",
             text=f"{user_name}さんから有給の申請が届きました。",
-            attachments=paid_holiday_approval_form(date=date, reason=reason, user_id=user_id, user_email=user_email),
+            blocks=paid_holiday_approval_form(user_name=user_name, date=date, reason=reason, user_id=user_id, user_email=user_email)
+            #attachments=paid_holiday_approval_form(date=date, reason=reason, user_id=user_id, user_email=user_email),
             )
 
 
@@ -156,15 +160,15 @@ def paid_holiday_approval_callback(ack: Ack, body, view: dict, client: WebClient
     approval_user_text = body["message"]["text"]
     channel_id = body["container"]["channel_id"]
     ts = body["container"]["message_ts"]
-    paid_holiday_info = body["message"]["attachments"][0]["fallback"]
-    attachments = body["message"]["attachments"]
+    paid_holiday_info = loads(body["actions"][0]["value"])
+    blocks = body["message"]["blocks"]
     ack()
     client.views_open(
         trigger_id=body["trigger_id"],
         view=paid_holiday_rejection_form(
             dict(
                 approval_user_text=approval_user_text,
-                attachments=attachments,
+                blocks=blocks,
                 ts=ts,
                 channel_id=channel_id,
                 paid_holiday_info=paid_holiday_info
@@ -180,63 +184,52 @@ def paid_holiday_rejection_callback(ack: Ack, body, view: dict, client: WebClien
     #TODO jsonモジュールをblockライブラリに移行
     paid_holiday_info = loads(body["view"]["private_metadata"])
     channel_id = paid_holiday_info["channel_id"]
-    attachments = paid_holiday_info["attachments"]
-    ack()
-    conversation =  client.conversations_open(users=paid_holiday_info["paid_holiday_info"]["user_id"])
-    dm_channel_id = conversation["channel"]["id"]
-    # ユーザに却下のDMを送信
-    client.chat_postMessage(
-        channel=dm_channel_id,
-        text="申請が却下されました。",
-        attachments=dumps(
-            [
-                {
-                    "blocks": [
-                        {
-                            "type": "section",
-                            "text": {
-                                "type": "plain_text",
-                                "text": f"・日時: {paid_holiday_info["paid_holiday_info"]["date"]}\n・理由: {paid_holiday_info["paid_holiday_info"]["reason"]}"
-                            }
-                        },
-                        {
-                            "type": "section",
-                            "text": {
-                                "type": "plain_text",
-                                "text": f"・却下理由: {reason}"
-                            }
-                        }
-                    ]
-                }
-            ]
-        )
-    )
-
-    user_name = client.users_info(user=body["user"]["id"])["user"]["profile"]["real_name"]
-    attachments[0]["blocks"][1] = dict(
+    blocks = paid_holiday_info["blocks"]
+    blocks[3] = dict(
         type="section",
         text=dict(
             type="plain_text",
-            text=f"{user_name}さんが却下しました。"
+            text=f"・却下理由: {reason}"
         )
     )
-
-    attachments[0]["blocks"].append(
+    request_user_dict = blocks.pop(1)
+    blocks.insert(
+        1,
         dict(
             type="section",
             text=dict(
                 type="plain_text",
-                text=f"・却下理由: {reason}",
-                emoji=True
+                text="申請が却下されました。"
             )
         )
     )
-
+    ack()
+    # ユーザに却下のDMを送信
+    conversation =  client.conversations_open(users=paid_holiday_info["paid_holiday_info"]["user_id"])
+    dm_channel_id = conversation["channel"]["id"]
+    client.chat_postMessage(
+        channel=dm_channel_id,
+        text="test",
+        blocks=blocks
+    )
+    # 有給登録のメッセージを編集する
+    user_name = client.users_info(user=body["user"]["id"])["user"]["profile"]["real_name"]
+    blocks[1] = request_user_dict
+    blocks.insert(
+        3,
+        dict(
+            type="section",
+            text=dict(
+                type="plain_text",
+                text=f"{user_name}さんが却下しました。"
+            )
+        )
+    )
     client.chat_update(
         #TODO bodyからチャンネルIDを取得したい
         channel=channel_id,
-        text=paid_holiday_info["approval_user_text"],
-        attachments=dumps(attachments),
+        text="test",
+        blocks=blocks,
         ts=paid_holiday_info["ts"]
     )
 
@@ -274,4 +267,4 @@ async def slack_events_endpoint(request: Request):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app="test:fast_api", host="0.0.0.0", port=3040, reload=True)
+    uvicorn.run(app="app:fast_api", host="0.0.0.0", port=3040, reload=True)

--- a/freee_workflow/paid_holiday.py
+++ b/freee_workflow/paid_holiday.py
@@ -5,7 +5,6 @@ def paid(date: str, reason: str, email: str, hr: HumanResourse):
     now = datetime.now()
     employees = hr.get_employees(year=now.year, month=now.month)["employees"]
     employee_id = get_employee_id(employees=employees, email=email)
-    print(employee_id)
     work_record = hr.update_employee_work_record(
         employee_id=employee_id,
         date=date,

--- a/slack_blocks/paid_holiday/block.py
+++ b/slack_blocks/paid_holiday/block.py
@@ -60,48 +60,56 @@ def paid_holiday_request_form():
     )
 
 
-def paid_holiday_approval_form(date: str, reason: str, user_id: str, user_email: str):
-    return dumps(
-        [
-            {
-                "fallback": dict(date=date, reason=reason, user_id=user_id, user_email=user_email),
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "plain_text",
-                            "text": f"・日時: {date}\n・理由: {reason}"
-                        }
-                    },
-                    {
-                        "type": "actions",
-                        "elements": [
-                            {
-                                "type": "button",
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "承認",
-                                    "emoji": True
-                                },
-                                "value": "approval",
-                                "action_id": "paid_holiday_request_approval"
-                            },
-                            {
-                                "type": "button",
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "差し戻し",
-                                    "emoji": True
-                                },
-                                "value": "rejection",
-                                "action_id": "paid_holiday_request_rejection"
-                            }
-                        ]
-                    }
-                ]
+def paid_holiday_approval_form(user_name: str, date: str, reason: str, user_id: str, user_email: str):
+    return [
+        {
+            "type": "divider"
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "plain_text",
+                "text": f"{user_name}さんから有給の申請が届きました。"
             }
-        ]
-    )
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "plain_text",
+                "text": f"・日時: {date}\n・理由: {reason}"
+            }
+        },
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "承認",
+                        "emoji": True
+                    },
+                    "style": "primary",
+                    "value": dumps(dict(date=date, reason=reason, user_id=user_id, user_email=user_email)),
+                    "action_id": "paid_holiday_request_approval"
+                },
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "差し戻し",
+                        "emoji": True
+                    },
+                    "style": "danger",
+                    "value": dumps(dict(date=date, reason=reason, user_id=user_id)),
+                    "action_id": "paid_holiday_request_rejection"
+                }
+            ]
+        },
+        {
+            "type": "divider"
+        }
+    ]
 
 
 def paid_holiday_rejection_form(private_metadata: dict):
@@ -154,18 +162,17 @@ def paid_holiday_rejection_form(private_metadata: dict):
 
 def paid_holiday_approval_resule(date: str, reason: str):
     return dumps(
-                    [
+            [
+                {
+                    "blocks": [
                         {
-                            "blocks": [
-                                {
-                                    "type": "section",
-                                    "text": {
-                                        "type": "plain_text",
-                                        "text": f"・日時: {date}\n・理由: {reason}"
-                                    }
-                                }
-                            ]
+                            "type": "section",
+                            "text": {
+                                "type": "plain_text",
+                                "text": f"・日時: {date}\n・理由: {reason}"
+                            }
                         }
                     ]
-                )
-            
+                }
+            ]
+        )


### PR DESCRIPTION
close #1 